### PR TITLE
chore: store Sanity deployment app id

### DIFF
--- a/apps/content/sanity.cli.ts
+++ b/apps/content/sanity.cli.ts
@@ -10,6 +10,7 @@ export default defineCliConfig({
    * Learn more at https://www.sanity.io/docs/cli#auto-updates
    */
   deployment: {
+    appId: 'bafsgievpqro878ty4sj5p64',
     autoUpdates: true,
   },
 });


### PR DESCRIPTION
## Summary
- add the Sanity deployment `appId` to `apps/content/sanity.cli.ts`
- keeps deploy configuration stable for unattended deploys
- avoids future CLI prompts for application id during `sanity deploy`

## Validation
- confirmed deploy to `https://jlc-carpentry.sanity.studio/` succeeded before this config update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration with an additional identifier to enhance application deployment tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->