### PR TITLE
feat: add llms.txt route for AI generative optimization

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,7 +1,15 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  async redirects() {
+    return [
+      {
+        source: '/llms',
+        destination: '/llms.txt',
+        permanent: true,
+      },
+    ];
+  },
   images: {
     deviceSizes: [640, 828, 1200],
     imageSizes: [48, 128, 256],

--- a/apps/web/src/app/llms.txt/route.ts
+++ b/apps/web/src/app/llms.txt/route.ts
@@ -1,0 +1,91 @@
+import { sanityFetch, siteSettingsQuery, servicesQuery } from '@/lib/sanity/queries';
+import { SiteSettings, SiteSettingsSchema, Service, ServiceSchema } from '@/lib/sanity/schemas';
+import { z } from 'zod';
+
+export const dynamic = 'force-static';
+export const revalidate = 86400;
+
+type LlmsData = {
+  siteSettings: SiteSettings;
+  services: Service[];
+};
+
+function buildServicesSection(services: Service[]): string {
+  return services.map((s) => `- ${s.title} — ${s.description}`).join('\n');
+}
+
+function buildServiceAreasSection(areas: string[]): string {
+  return areas.join(', ');
+}
+
+function buildBusinessHours(hours: { day: string; hours: string }[]): string {
+  return hours.map((h) => `- ${h.day}: ${h.hours}`).join('\n');
+}
+
+function buildLlmsText({ siteSettings, services }: LlmsData): string {
+  const { company, location, contact, socialMedia, licenses } = siteSettings;
+  const address = location?.address;
+  const suburb = address?.suburb ?? 'Alphington';
+  const state = address?.state ?? 'VIC';
+
+  const lines = [
+    `# ${company.name}`,
+    '',
+    '## About',
+    '',
+    ...(company.description ? [company.description] : []),
+    `Based in ${suburb}, ${state}, Melbourne, Victoria, Australia.`,
+    ...(company.yearsOfExperience ? [`${company.yearsOfExperience}+ years of experience.`] : []),
+    ...(company.abn ? [`ABN: ${company.abn}`] : []),
+    '',
+    '## Services',
+    '',
+    buildServicesSection(services),
+    '',
+  ];
+
+  if (location?.serviceAreas && location.serviceAreas.length > 0) {
+    lines.push('## Service Areas', '', buildServiceAreasSection(location.serviceAreas), '');
+  }
+
+  lines.push('## Contact', '');
+
+  if (contact?.phone) lines.push(`- Phone: ${contact.phone}`);
+  if (contact?.email) lines.push(`- Email: ${contact.email}`);
+  if (socialMedia?.website) lines.push(`- Website: ${socialMedia.website}`);
+
+  lines.push('');
+
+  if (socialMedia?.googleBusinessLink || socialMedia?.instagram || socialMedia?.facebook) {
+    lines.push('## Social', '');
+    if (socialMedia.googleBusinessLink) lines.push(`- Google Business: ${socialMedia.googleBusinessLink}`);
+    if (socialMedia.instagram) lines.push(`- Instagram: ${socialMedia.instagram}`);
+    if (socialMedia.facebook) lines.push(`- Facebook: ${socialMedia.facebook}`);
+    lines.push('');
+  }
+
+  if (licenses && licenses.length > 0) {
+    lines.push('## Licenses', '');
+    licenses.forEach((l) => lines.push(`- ${l.name}: ${l.number}`));
+    lines.push('');
+  }
+
+  if (contact?.businessHours && contact.businessHours.length > 0) {
+    lines.push('## Business Hours', '', buildBusinessHours(contact.businessHours), '');
+  }
+
+  return lines.join('\n');
+}
+
+export async function GET(): Promise<Response> {
+  const [siteSettings, services] = await Promise.all([
+    sanityFetch({ query: siteSettingsQuery, schema: SiteSettingsSchema }),
+    sanityFetch({ query: servicesQuery, schema: z.array(ServiceSchema) }),
+  ]);
+
+  const body = buildLlmsText({ siteSettings, services });
+
+  return new Response(body, {
+    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+  });
+}

--- a/docs/plans/llms-txt-route.md
+++ b/docs/plans/llms-txt-route.md
@@ -1,0 +1,103 @@
+# Plan: Add llms.txt Route for AI Generative Optimization
+
+## Context
+
+AI crawlers (ChatGPT, Perplexity, Claude, etc.) increasingly read a plain-text `llms.txt` file at the root of a site to understand its purpose, services, and contact info without parsing HTML. Adding this improves AI-generated search answers ("generative engine optimization"). The reference implementation in `ses-next` fetches live data from Sanity and returns it as `text/plain`.
+
+We also need a redirect so `/llms` → `/llms.txt` for convenience.
+
+---
+
+## What to Build
+
+### 1. New route: `apps/web/src/app/llms.txt/route.ts`
+
+A Next.js Route Handler that:
+- Fetches `siteSettings` and `services` from Sanity in parallel using the existing `sanityFetch` helper and Zod schemas
+- Builds a plain-text document and returns it as `text/plain; charset=utf-8`
+- Uses `export const dynamic = 'force-static'` and `export const revalidate = 86400` (24h, matching the reference)
+
+**Content sections to include:**
+
+```
+# {company.name}
+
+## About
+
+{company.description or shortDescription}
+Based in {location.address.suburb}, Melbourne, Victoria, Australia.
+{company.yearsOfExperience}+ years of experience.
+ABN: {company.abn}
+
+## Services
+
+- {service.title} — {service.description}
+  (repeated per service)
+
+## Service Areas
+
+{location.serviceAreas joined by ', '}
+
+## Contact
+
+- Phone: {contact.phone}
+- Email: {contact.email}
+- Website: https://www.jlccarpentrybuildingservices.com.au
+
+## Social
+
+- Google Business: {socialMedia.googleBusinessLink}
+- Instagram: {socialMedia.instagram}
+- Facebook: {socialMedia.facebook}
+
+## Licenses
+
+- {license.name}: {license.number}
+  (repeated per license)
+
+## Business Hours
+
+- {day}: {hours}
+  (repeated per businessHours entry)
+```
+
+Fields are conditionally included (skip if null/undefined), matching the pattern in ses-next.
+
+**Reuse existing utilities:**
+- `sanityFetch` from `@/lib/sanity/queries`
+- `SiteSettingsSchema`, `SiteSettings` type, `ServiceSchema`, `Service` type from `@/lib/sanity/schemas`
+- `siteSettingsQuery`, `servicesQuery` GROQ queries from `@/lib/sanity/queries`
+- `z.array(ServiceSchema)` for the services array validation
+
+### 2. Redirect in `apps/web/next.config.ts`
+
+Add a `redirects` function that maps `/llms` → `/llms.txt` (permanent redirect, status 308):
+
+```ts
+async redirects() {
+  return [
+    {
+      source: '/llms',
+      destination: '/llms.txt',
+      permanent: true,
+    },
+  ];
+},
+```
+
+---
+
+## Files to Create / Modify
+
+| Action | File |
+|--------|------|
+| **Create** | `apps/web/src/app/llms.txt/route.ts` |
+| **Modify** | `apps/web/next.config.ts` |
+
+---
+
+## Verification
+
+1. `npm run dev -w web` — visit `http://localhost:3000/llms.txt` and confirm plain-text response with company/service data
+2. Visit `http://localhost:3000/llms` — confirm it redirects to `/llms.txt`
+3. `npm run type:check` — no TypeScript errors


### PR DESCRIPTION
## Summary

- Adds a static `/llms.txt` route that serves structured plain-text company info fetched live from Sanity CMS (company details, services, service areas, contact, social links, licenses, business hours)
- Uses `force-static` generation with 24-hour revalidation for performance
- Adds a permanent redirect from `/llms` → `/llms.txt` in `next.config.ts` for convenience

## Test plan

- [ ] Start dev server and visit `http://localhost:3000/llms.txt` — confirm plain-text response with company/service data
- [ ] Visit `http://localhost:3000/llms` — confirm it redirects to `/llms.txt`
- [ ] TypeScript type check passes (`npm run type:check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `llms.txt` endpoint serving standardized company information, services, and metadata for AI tools and search engines to discover site details.
  * Configured permanent redirect from `/llms` to `/llms.txt` for easy access.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dejanvasic85/jlc-carpentry/pull/564?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->