### PR TITLE
Remove "Licensed Builder" claims from marketing copy

### DIFF
--- a/apps/web/src/app/(landing)/free-quote/page.tsx
+++ b/apps/web/src/app/(landing)/free-quote/page.tsx
@@ -171,7 +171,7 @@ export default async function FreeQuotePage() {
         </div>
 
         <div className="relative z-20 max-w-5xl mx-auto px-6 pt-14 pb-10">
-          <div className="max-w-2xl">
+          <div className="max-w-2xl mx-auto text-center">
             <p className="text-jlc-blue font-semibold text-sm uppercase tracking-widest mb-3">
               Melbourne&apos;s Trusted Carpenter
             </p>
@@ -187,7 +187,7 @@ export default async function FreeQuotePage() {
 
             <TrustBadges />
 
-            <div className="flex flex-col sm:flex-row gap-3 mt-8">
+            <div className="flex flex-col sm:flex-row gap-3 mt-8 justify-center">
               <a
                 href="#quote-form"
                 className="flex items-center justify-center gap-2 bg-jlc-blue hover:bg-jlc-blue-dark text-white font-bold text-base px-8 py-4 rounded-lg transition-colors shadow-lg"

--- a/apps/web/src/app/(landing)/free-quote/page.tsx
+++ b/apps/web/src/app/(landing)/free-quote/page.tsx
@@ -11,11 +11,11 @@ import PhoneCallLink from '@/components/landing/PhoneCallLink';
 export const metadata: Metadata = {
   title: 'Get a Free Quote | JLC Carpentry & Building Services Melbourne',
   description:
-    'Licensed Melbourne carpenter. Custom decks, pergolas, kitchen and bathroom renovations. 5-star Google rated. 7-year structural warranty. Free quotes with no obligation.',
+    'Melbourne carpenter. Custom decks, pergolas, kitchen and bathroom renovations. 5-star Google rated. 7-year structural warranty. Free quotes with no obligation.',
   openGraph: {
     title: 'Get a Free Quote | JLC Carpentry & Building Services Melbourne',
     description:
-      'Licensed Melbourne carpenter. Custom decks, pergolas, kitchen and bathroom renovations. 5-star Google rated. 7-year structural warranty.',
+      'Melbourne carpenter. Custom decks, pergolas, kitchen and bathroom renovations. 5-star Google rated. 7-year structural warranty.',
     type: 'website',
     locale: 'en_AU',
     siteName: 'JLC Carpentry & Building Services',
@@ -144,7 +144,6 @@ const trustStats = [
   { value: '30+', label: 'Projects Completed' },
   { value: '5-Star', label: 'Google Rated' },
   { value: '7-Year', label: 'Structural Warranty' },
-  { value: 'Licensed', label: 'Builder VIC' },
 ] as const;
 
 export default async function FreeQuotePage() {
@@ -177,7 +176,7 @@ export default async function FreeQuotePage() {
               Melbourne&apos;s Trusted Carpenter
             </p>
             <h1 className="font-display text-5xl sm:text-6xl md:text-7xl leading-none mb-4">
-              LICENSED MELBOURNE CARPENTER.
+              MELBOURNE CARPENTER.
             </h1>
             <p className="text-xl sm:text-2xl font-light text-white/90 mb-3">
               Quality workmanship backed by a 7-year structural warranty.

--- a/apps/web/src/components/landing/TrustBadges.tsx
+++ b/apps/web/src/components/landing/TrustBadges.tsx
@@ -55,7 +55,7 @@ const badges: TrustBadge[] = [
 
 export default function TrustBadges() {
   return (
-    <div className="flex flex-wrap justify-center gap-3 sm:gap-4" role="list" aria-label="Trust credentials">
+    <div className="grid grid-cols-2 justify-items-start gap-3 sm:gap-4" role="list" aria-label="Trust credentials">
       {badges.map((badge) => (
         <div
           key={badge.label}

--- a/apps/web/src/components/landing/TrustBadges.tsx
+++ b/apps/web/src/components/landing/TrustBadges.tsx
@@ -55,7 +55,7 @@ const badges: TrustBadge[] = [
 
 export default function TrustBadges() {
   return (
-    <div className="grid grid-cols-2 justify-items-start gap-3 sm:gap-4" role="list" aria-label="Trust credentials">
+    <div className="grid grid-cols-2 justify-items-center gap-3 sm:gap-4" role="list" aria-label="Trust credentials">
       {badges.map((badge) => (
         <div
           key={badge.label}

--- a/apps/web/src/components/landing/TrustBadges.tsx
+++ b/apps/web/src/components/landing/TrustBadges.tsx
@@ -27,19 +27,6 @@ const badges: TrustBadge[] = [
   },
   {
     icon: (
-      <svg className="w-6 h-6 text-jlc-blue" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth={2}
-          d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
-        />
-      </svg>
-    ),
-    label: 'Licensed Builder',
-  },
-  {
-    icon: (
       <svg className="w-6 h-6 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
         <path
           strokeLinecap="round"


### PR DESCRIPTION
## Summary
Removed references to "Licensed Builder" status from the landing page and free quote page. This includes removing the trust badge, updating metadata descriptions, removing the trust stat, and updating the main headline to remove the "LICENSED" qualifier.

## Key Changes
- Removed the "Licensed Builder" trust badge from the TrustBadges component
- Updated page metadata descriptions to remove "Licensed" qualifier from the carpenter description
- Removed the "Licensed Builder VIC" trust stat from the free quote page
- Updated the main headline from "LICENSED MELBOURNE CARPENTER." to "MELBOURNE CARPENTER."

## Implementation Details
These changes ensure consistent messaging across the landing pages by removing licensing claims that may not be currently applicable or verified. The core value propositions (quality workmanship, 7-year structural warranty, 5-star Google rating, and project portfolio) remain prominently featured.

https://claude.ai/code/session_016JyzkP2BT8y5NhCaLkSuu2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated landing page messaging by removing licensing references from metadata and hero headline.
  * Modified displayed credentials, replacing the licensed builder badge with a 7-year structural warranty badge.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dejanvasic85/jlc-carpentry/pull/580?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->