### PR TITLE
fix: renovate lock file maintenance memory fix

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,7 +23,7 @@
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": true,
-    "recreateWhen": "always",
+    "recreateWhen": "auto",
     "rebaseWhen": "behind-base-branch",
     "schedule": ["before 4am on monday"],
     "prBodyDefinitions": {


### PR DESCRIPTION
## Summary

- Changed `recreateWhen` from `"always"` to `"auto"` in `renovate.json` lockFileMaintenance config
- Mirrors the same fix applied in [ses-next #553](https://github.com/dejanvasic85/ses-next/pull/553)

With `"always"`, Renovate was unconditionally regenerating the entire lockfile on every run, blowing past kernel memory limits. With `"auto"`, it only recreates when the lockfile actually needs updating.

## Test plan

- [ ] Verify next Renovate lock file maintenance PR runs without OOM errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)