### PR TITLE
ci: replace wait-for-vercel-preview with vercel/wait-for-deployment-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ jobs:
     container:
       image: mcr.microsoft.com/playwright:v1.61.0-jammy
     timeout-minutes: 10
+    permissions:
+      contents: read
+      deployments: read
+      statuses: read
 
     steps:
       - uses: actions/checkout@v7
@@ -35,17 +39,17 @@ jobs:
 
       - name: Wait for Vercel deployment
         id: vercel-deployment
-        uses: patrickedqvist/wait-for-vercel-preview@v1.3.3
+        uses: vercel/wait-for-deployment-action@0e2b0c5c5cce31f1648108aeec56467187aca037 # main
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          max_timeout: 300
-          check_interval: 10
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          timeout: 300
+          check-interval: 10
 
       - name: Run Playwright tests
         run: pnpm run test:e2e
         working-directory: ./apps/web
         env:
-          PLAYWRIGHT_TEST_BASE_URL: ${{ steps.vercel-deployment.outputs.url }}
+          PLAYWRIGHT_TEST_BASE_URL: ${{ steps.vercel-deployment.outputs.deployment-url }}
           HOME: /root
 
       - name: Upload test results


### PR DESCRIPTION
## Summary
- Replace unmaintained `patrickedqvist/wait-for-vercel-preview@v1.3.3` with the official `vercel/wait-for-deployment-action`
- No tagged releases exist for the new action yet, so it's pinned to the current `main` commit SHA with a `# main` comment, which Renovate can track for automatic digest updates
- Add job-level `permissions` (`deployments: read`, `statuses: read`) required by the new action
- Update input/output names (`token` → `github-token`, `max_timeout` → `timeout`, `check_interval` → `check-interval`, `outputs.url` → `outputs.deployment-url`)

## Test plan
- [ ] CI workflow runs successfully and waits for the Vercel preview deployment
- [ ] Playwright e2e tests receive the correct `PLAYWRIGHT_TEST_BASE_URL`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated preview deployment checks to use read-only permissions.
  * Improved deployment verification with a pinned action release, clearer timeout settings, and deployment URL reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->